### PR TITLE
chore(scrapers): deprecate direct ChinaXiv harvesters

### DIFF
--- a/src/harvest_chinaxiv.py
+++ b/src/harvest_chinaxiv.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 """
+DEPRECATED: Direct ChinaXiv scraping via BrightData.
+Use Internet Archive harvester in src/harvest_ia.py instead.
+
 Harvest fresh papers from ChinaXiv using BrightData Web Unlocker.
 
 Scrapes papers by sequential ID probing for specified month ranges.

--- a/src/harvest_chinaxiv_optimized.py
+++ b/src/harvest_chinaxiv_optimized.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 """
+DEPRECATED: Direct ChinaXiv scraping.
+Use Internet Archive harvester in src/harvest_ia.py instead.
+
 Optimized ChinaXiv harvester with smart ID discovery.
 
 Uses homepage parsing + binary search to find paper ID ranges,

--- a/src/harvest_chinaxiv_smart.py
+++ b/src/harvest_chinaxiv_smart.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 """
+DEPRECATED: Direct ChinaXiv scraping.
+Use Internet Archive harvester in src/harvest_ia.py instead.
+
 Smart ChinaXiv harvester using pre-analyzed max IDs.
 
 Based on IA data + homepage analysis, uses known reasonable maxes


### PR DESCRIPTION
Add deprecation notices to legacy scrapers; steer users to src/harvest_ia.py per PRD.\n\n@codex review