### PR TITLE
docs(tex-guard): clarify preserved tokens

### DIFF
--- a/src/tex_guard.py
+++ b/src/tex_guard.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from typing import List, Tuple
 
 
+# Note: We preserve not only math, but also citations and select LaTeX markup.
+# The token prefix remains MATH_ for backward compatibility.
 MATH_TOKEN_FMT = "⟪MATH_{:04d}⟫"
 
 
@@ -71,4 +73,3 @@ def verify_token_parity(source_mappings: List[Masking], translated_text: str) ->
             ok = False
             break
     return ok
-


### PR DESCRIPTION
Clarify that tokens preserve math, citations, and select LaTeX commands; keep MATH_ prefix for compatibility.\n\n@codex review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update comments in `src/tex_guard.py` to state tokens preserve math, citations, and select LaTeX while retaining the `MATH_` prefix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc7b03af5261b971bb505820a99160d285e9d406. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->