### PR TITLE
perf(translate): optional paragraph batching (flagged)

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -26,6 +26,8 @@ models:
   default_slug: "deepseek/deepseek-v3.2-exp"
   alternates:
     - "z-ai/glm-4.5-air"
+translation:
+  batch_paragraphs: false
 
 glossary:
   - zh: "机器学习"


### PR DESCRIPTION
Add experimental batching to translate_paragraphs when translation.batch_paragraphs=true in config. Falls back to per-paragraph on mismatch.\n\n@codex review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds config-flagged batching to `translate_paragraphs` with chunking and safe fallback; introduces `translation.batch_paragraphs` (default false).
> 
> - **Translation Service (`src/services/translation_service.py`)**:
>   - Enable optional batching in `translate_paragraphs` when `translation.batch_paragraphs` is true.
>   - Batch logic: chunk via `chunk_paragraphs`, join with sentinel `\n\n⟪PARA_BREAK⟫\n\n`, translate once, then split; fallback to per-paragraph if counts mismatch.
> - **Config (`src/config.yaml`)**:
>   - Add `translation.batch_paragraphs: false` flag to toggle batching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e73a0d7b166f360f4abadf82d3db39430fa3b24d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->