### PR TITLE
perf(translate): optional paragraph batching + glossary passthrough (PR8 cleanup)

### DIFF
--- a/src/services/translation_service.py
+++ b/src/services/translation_service.py
@@ -183,7 +183,6 @@ class TranslationService:
             List of translated paragraphs
         """
         model = model or self.model
-<<<<<<< HEAD
         glossary_eff = self.glossary if glossary_override is None else glossary_override
         # Optional batching to reduce API calls; disabled by default
         batch_enabled = (
@@ -208,12 +207,6 @@ class TranslationService:
                     out.append(self.translate_field(p, model, dry_run, glossary_override=glossary_eff))
             else:
                 out.extend(parts)
-=======
-        glossary_eff = glossary_override if glossary_override is not None else self.glossary
-        out: List[str] = []
-        for p in paragraphs:
-            out.append(self.translate_field(p, model, dry_run, glossary_override=glossary_eff))
->>>>>>> origin/main
         return out
     
     def translate_record(


### PR DESCRIPTION
This PR replaces the conflicted PR8 branch with a clean implementation based on origin/main.

Key points:
- Adds optional paragraph batching behind translation.batch_paragraphs (default: false).
- Uses a safe sentinel join/split with fallback to per-paragraph when counts mismatch.
- Preserves glossary overrides end-to-end: translate_field, translate_paragraphs, and translate_record.
- Resolves stray conflict markers seen on origin/main in translate_paragraphs.

Tests:
- Ran targeted tests: tests/test_translate.py, tests/test_config.py, tests/test_select_and_fetch.py, tests/test_e2e_simple.py — all green locally.

After open:
- Commenting @codex review to trigger Codex.
